### PR TITLE
Add missing brackets to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ elements directly in javascript.
 //reactive hello world
 var h = require('hscrpt')
 var name
-document.body.appendChild(h('div',
-  h('h1', 'Hello, ', name = h('span', 'World')),
+document.body.appendChild(h('div', [
+  h('h1', [ 'Hello, ', name = h('span', 'World') ]),
   h('input', {oninput: function (ev) {
     name.textContent = ev.target.value
-  })
-))
+  }})
+]))
 ```
 
 frameworks come and go. but the DOM doesn't change,


### PR DESCRIPTION
Fixes #2.

Fixes the type errors. Doesn't start off with the word "World", though... https://jsfiddle.net/39Lr1h72/